### PR TITLE
Add: 예약할 호텔이름, 객실이름, 총 가격 state 관리 및 상세페이지 css 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@testing-library/user-event": "^13.5.0",
         "axios": "^0.27.2",
         "classnames": "^2.3.2",
+        "date-fns": "^1.30.1",
         "react": "^18.2.0",
         "react-datepicker": "^4.8.0",
         "react-dom": "^18.2.0",
@@ -6935,16 +6936,9 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "2.29.3",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
-      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
-      "engines": {
-        "node": ">=0.11"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
-      }
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -14552,6 +14546,18 @@
       "peerDependencies": {
         "react": "^16.9.0 || ^17 || ^18",
         "react-dom": "^16.9.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/react-datepicker/node_modules/date-fns": {
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
+      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/react-dev-utils": {
@@ -22564,9 +22570,9 @@
       }
     },
     "date-fns": {
-      "version": "2.29.3",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
-      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
     },
     "debug": {
       "version": "4.3.4",
@@ -27898,6 +27904,13 @@
         "prop-types": "^15.7.2",
         "react-onclickoutside": "^6.12.0",
         "react-popper": "^2.2.5"
+      },
+      "dependencies": {
+        "date-fns": {
+          "version": "2.29.3",
+          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
+          "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
+        }
       }
     },
     "react-dev-utils": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@testing-library/user-event": "^13.5.0",
     "axios": "^0.27.2",
     "classnames": "^2.3.2",
-    "date-fns": "^1.30.1",
     "react": "^18.2.0",
     "react-datepicker": "^4.8.0",
     "react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@testing-library/user-event": "^13.5.0",
     "axios": "^0.27.2",
     "classnames": "^2.3.2",
+    "date-fns": "^1.30.1",
     "react": "^18.2.0",
     "react-datepicker": "^4.8.0",
     "react-dom": "^18.2.0",

--- a/src/atom.js
+++ b/src/atom.js
@@ -24,3 +24,11 @@ export const endDateState = atom({
   key: 'endDateState',
   default: null,
 });
+
+export const reservInfoState = atom({
+  key: 'reservInfoState',
+  dafault: {
+    name: '제주도 오라이',
+    totalPrice: 100000,
+  },
+});

--- a/src/atom.js
+++ b/src/atom.js
@@ -27,8 +27,9 @@ export const endDateState = atom({
 
 export const reservInfoState = atom({
   key: 'reservInfoState',
-  dafault: {
-    name: '제주도 오라이',
-    totalPrice: 100000,
+  default: {
+    name: '',
+    roomType: '',
+    totalPrice: 0,
   },
 });

--- a/src/pages/detail/Detail.js
+++ b/src/pages/detail/Detail.js
@@ -1,4 +1,6 @@
 import { useState, useEffect } from 'react';
+import { useRecoilState } from 'recoil';
+import { reservInfoState, startDateState, endDateState } from '../../atom';
 import Information from './components/Information';
 import Review from './components/Review';
 import RoomGuide from './components/RoomGuide';
@@ -9,6 +11,9 @@ import EventModal from './components/EventModal';
 import SubjectSlide from './components/SubjectSlide';
 
 const Detail = () => {
+  const [info, setInfo] = useRecoilState(reservInfoState);
+  const [startDate, setStartDate] = useRecoilState(startDateState);
+  const [endDate, setEndDate] = useRecoilState(endDateState);
   const [openModal, setOpenModal] = useState(false);
   const [showData, setShowData] = useState();
   const [component, setComponent] = useState(1);
@@ -16,6 +21,7 @@ const Detail = () => {
   const handleClickBtn = () => {
     setOpenModal(true);
   };
+
   const clickTab = (e) => {
     switch (e.target.value) {
       case '객실안내/예약':
@@ -33,6 +39,10 @@ const Detail = () => {
       .then((res) => res.json())
       .then((data) => {
         setShowData(data.roomTypeData);
+        setInfo({
+          ...info,
+          name: data.roomTypeData.name,
+        });
       });
   }, []);
 

--- a/src/pages/detail/components/Room.js
+++ b/src/pages/detail/components/Room.js
@@ -1,12 +1,21 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
+import { startDateState, endDateState, reservInfoState } from '../../../atom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faAngleRight } from '@fortawesome/free-solid-svg-icons';
 import { faImages } from '@fortawesome/free-solid-svg-icons';
-import * as S from './Room.styled';
-import { useState } from 'react';
+
 import Slide from './Slide';
 import UseModal from './UseModal';
 
+import * as S from './Room.styled';
+
 const Room = ({ roomType }) => {
+  const navigate = useNavigate();
+  const [startDate] = useRecoilState(startDateState);
+  const [endDate] = useRecoilState(endDateState);
+  const [info, setInfo] = useRecoilState(reservInfoState);
   const [openBtn, setOpenBtn] = useState(false);
   const [useBtn, setUseBtn] = useState(false);
 
@@ -16,6 +25,18 @@ const Room = ({ roomType }) => {
 
   const handleUseBtn = () => {
     setUseBtn(true);
+  };
+
+  const handleResrvBtn = () => {
+    navigate('/reservation');
+    window.scrollTo({
+      top: 0,
+    });
+    setInfo({
+      ...info,
+      roomType: roomType.type,
+      totalPrice: roomType.price * (endDate.getDate() - startDate.getDate()),
+    });
   };
 
   return (
@@ -50,7 +71,9 @@ const Room = ({ roomType }) => {
               )}
             </div>
             <div>
-              <button className='reservation-button'>예약</button>
+              <button className='reservation-button' onClick={handleResrvBtn}>
+                예약
+              </button>
             </div>
           </div>
         </div>

--- a/src/pages/detail/components/Room.js
+++ b/src/pages/detail/components/Room.js
@@ -18,6 +18,8 @@ const Room = ({ roomType }) => {
   const [info, setInfo] = useRecoilState(reservInfoState);
   const [openBtn, setOpenBtn] = useState(false);
   const [useBtn, setUseBtn] = useState(false);
+  const [period] = useState(startDate.getDate() - startDate.getDate());
+  // const [period, setPeriod] = useState(EndDate.getDate() - startDate.getDate());
 
   const handleToggleBtn = () => {
     setOpenBtn((openBtn) => !openBtn);
@@ -35,7 +37,7 @@ const Room = ({ roomType }) => {
     setInfo({
       ...info,
       roomType: roomType.type,
-      totalPrice: roomType.price * (endDate.getDate() - startDate.getDate()),
+      totalPrice: roomType.price * period,
     });
   };
 
@@ -54,7 +56,10 @@ const Room = ({ roomType }) => {
             <div className='remain'>남은객실 {roomType.remain}개</div>
             <div className='flex underline-style'>
               <strong>가격</strong>
-              <strong className='font-style'>{roomType.price}원</strong>
+              <strong className='font-style'>
+                {roomType.price}원{period >= 0 && `/${period}박`}
+                {/* {roomType.price}원{period >= 2 && `/${period}박`} */}
+              </strong>
             </div>
             <div className='flex-btn'>
               <button className='use-button' onClick={handleUseBtn}>
@@ -72,7 +77,8 @@ const Room = ({ roomType }) => {
             </div>
             <div>
               <button className='reservation-button' onClick={handleResrvBtn}>
-                예약
+                예약하기{period >= 0 && ` | ${period * roomType.price}원 (${period}박)`}
+                {/* 예약{period >= 2 && ` | ${period * roomType.price}원 (${period}박)`} */}
               </button>
             </div>
           </div>

--- a/src/pages/detail/components/Room.styled.js
+++ b/src/pages/detail/components/Room.styled.js
@@ -58,6 +58,7 @@ export const RoomType = styled.div`
     color: #fff;
     border-radius: 4px;
     border: none;
+    font-size: 18px;
     text-align: center;
   }
   .remain {

--- a/src/pages/reservation/components/Main.js
+++ b/src/pages/reservation/components/Main.js
@@ -1,8 +1,12 @@
 import { useEffect, useState } from 'react';
 import axios from 'axios';
+import { useRecoilState } from 'recoil';
+import { reservInfoState } from '../../../atom';
+
 import { MainContainerStyle } from './Main.Styled';
 
 const Main = () => {
+  const [info] = useRecoilState(reservInfoState);
   const [inputs, setInputs] = useState({
     userName: '',
     phone: '',
@@ -115,7 +119,7 @@ const Main = () => {
           <h3 className='title'>할인 수단 선택</h3>
           <div className='line'>
             <div>구매총액</div>
-            <div className='totalPrice'>40,000원</div>
+            <div className='totalPrice'>{info.totalPrice.toLocaleString()}원</div>
           </div>
           <button className='button-line'>
             사용 가능 쿠폰 <span>{coupon}</span>장

--- a/src/pages/reservation/components/Sub.js
+++ b/src/pages/reservation/components/Sub.js
@@ -1,10 +1,21 @@
+import { useRecoilState } from 'recoil';
+import { startDateState, endDateState } from '../../../atom';
+
 import { SubContainerStyle } from '../Reservation.Styled';
 
 // 필요한 데이터
 // 숙소이름, 객실타입, 숙박일수,
-//   체크인 날짜, 체크아웃 날짜, 전체금액
+// 전체금액
+// 체크인 날짜, 체크아웃 날짜,
 
 const Sub = () => {
+  const [startDate] = useRecoilState(startDateState);
+  const [endDate] = useRecoilState(endDateState);
+  const week = ['일', '월', '화', '수', '목', '금', '토'];
+  console.log(week[startDate.getDay()]);
+
+  // const changeDay
+
   return (
     <>
       <SubContainerStyle>
@@ -24,13 +35,13 @@ const Sub = () => {
           <div>
             <div className='title'>체크인</div>
             <div className='content'>
-              <span>09.24</span> <span>금</span> <span>14:00</span>
+              <span>09.{startDate.getDate()}</span> <span>{week[startDate.getDay()]}</span> <span>15:00</span>
             </div>
           </div>
           <div>
             <div className='title'>체크아웃</div>
             <div className='content'>
-              <span>09.25</span> <span>토</span> <span>11:00</span>
+              <span>09.{startDate.getDate()}</span> <span>{week[startDate.getDay()]}</span> <span>11:00</span>
             </div>
           </div>
 

--- a/src/pages/reservation/components/Sub.js
+++ b/src/pages/reservation/components/Sub.js
@@ -1,20 +1,17 @@
 import { useRecoilState } from 'recoil';
-import { startDateState, endDateState } from '../../../atom';
+import { startDateState, endDateState, reservInfoState } from '../../../atom';
 
 import { SubContainerStyle } from '../Reservation.Styled';
 
 // 필요한 데이터
-// 숙소이름, 객실타입, 숙박일수,
 // 전체금액
-// 체크인 날짜, 체크아웃 날짜,
+// 완성 : 체크인 날짜, 체크아웃 날짜, 숙소이름, 객실타입, 숙박일수,
 
 const Sub = () => {
   const [startDate] = useRecoilState(startDateState);
   const [endDate] = useRecoilState(endDateState);
+  const [info] = useRecoilState(reservInfoState);
   const week = ['일', '월', '화', '수', '목', '금', '토'];
-  console.log(week[startDate.getDay()]);
-
-  // const changeDay
 
   return (
     <>
@@ -23,13 +20,14 @@ const Sub = () => {
           <div>
             <div className='title'>숙소이름</div>
             <div className='content'>
-              <span>홍대</span> <span>스타일 게스트하우스</span>
+              <span>{info.name}</span>
             </div>
           </div>
           <div>
             <div className='title'>객실타입/기간</div>
             <div className='content'>
-              <span>더블룸</span> (<span>객실내 전용욕실</span>) / <span>1</span>박
+              <span>{info.roomType}</span> / <span>{startDate.getDate() - startDate.getDate()}</span>박
+              {/* <span>{info.type}</span> / <span>{endDate.getDate() - startDate.getDate()}</span>박 */}
             </div>
           </div>
           <div>
@@ -42,6 +40,7 @@ const Sub = () => {
             <div className='title'>체크아웃</div>
             <div className='content'>
               <span>09.{startDate.getDate()}</span> <span>{week[startDate.getDay()]}</span> <span>11:00</span>
+              {/* <span>09.{endDate.getDate()}</span> <span>{week[endDate.getDay()]}</span> <span>11:00</span> */}
             </div>
           </div>
 
@@ -50,7 +49,7 @@ const Sub = () => {
               <span className='bold'>총 결제 금액</span>
               <span>(VAT포함)</span>
               <div className='totalPrice'>
-                <span>329,000</span>
+                <span>{info.totalPrice.toLocaleString()}</span>
                 <span>원</span>
               </div>
             </div>

--- a/src/pages/reservation/components/Sub.js
+++ b/src/pages/reservation/components/Sub.js
@@ -3,10 +3,6 @@ import { startDateState, endDateState, reservInfoState } from '../../../atom';
 
 import { SubContainerStyle } from '../Reservation.Styled';
 
-// 필요한 데이터
-// 전체금액
-// 완성 : 체크인 날짜, 체크아웃 날짜, 숙소이름, 객실타입, 숙박일수,
-
 const Sub = () => {
   const [startDate] = useRecoilState(startDateState);
   const [endDate] = useRecoilState(endDateState);

--- a/src/pages/reservation/components/Sub.js
+++ b/src/pages/reservation/components/Sub.js
@@ -1,5 +1,9 @@
 import { SubContainerStyle } from '../Reservation.Styled';
 
+// 필요한 데이터
+// 숙소이름, 객실타입, 숙박일수,
+//   체크인 날짜, 체크아웃 날짜, 전체금액
+
 const Sub = () => {
   return (
     <>


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 상세페이지에서 예약페이지로 넘어오는 호텔 이름, 객실 이름, 총 가격 state로 관리 및 상세페이지 css 수정

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 호텔이름, 객실이름, 총 가격, 숙박기간, 숙박기간에 따른 총 가격을 상세페이지에서 예약페이지로 넘어갈 때
같이 넘어갈 수 있도록 state로 관리
2. 숙박일수가 2박이 넘어가면 각 방마다 컴포넌트에 숙박일자, 총 가격 구현


<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 처음에는 호텔이름, 객실 이름 등을 따로따로 recoil에서 관리하려고 했는데 그러면 관리가 어려울 것 같아서
reservInfoState라는 하나의 상태에서 객체로 관리했습니다. 
리코일을 활용하는 방법을 알게 된 것 같습니다. 시작날짜와 끝 날짜도 아예 한번에 묶었으면 더 좋을 것 같습니다..!

<br />

## :: 기타 질문 및 특이 사항
- 주석 처리 된 부분은 나중에 날짜 선택시 endDate가 업데이트되는 기능을 구현할 때 사용할 부분이라 남겨놨습니다
