### PR TITLE
Fix: 예약페이지에서 유효성검사 기준에 따라 생성되는 모달의 내용 변경

### DIFF
--- a/src/pages/reservation/Reservation.js
+++ b/src/pages/reservation/Reservation.js
@@ -1,13 +1,34 @@
+import { useState } from 'react';
 import Main from './components/Main';
 import Sub from './components/Sub';
 
 import { ReservationStyle } from './Reservation.Styled';
 
 const Reservation = () => {
+  // const [submitName, setSubmitName] = useState();
+  const [inputs, setInputs] = useState({
+    userName: '',
+    phone: '',
+    coupon: 0,
+    pointInput: '',
+  });
+  const [point, setPoint] = useState(0);
+  const [checkList, setCheckList] = useState([]);
+  const [nameValid, setNameValid] = useState(true);
+
   return (
     <ReservationStyle>
-      <Main />
-      <Sub />
+      <Main
+        inputs={inputs}
+        setInputs={setInputs}
+        point={point}
+        setPoint={setPoint}
+        checkList={checkList}
+        setCheckList={setCheckList}
+        nameValid={nameValid}
+        setNameValid={setNameValid}
+      />
+      <Sub inputs={inputs} point={point} checkList={checkList} />
     </ReservationStyle>
   );
 };

--- a/src/pages/reservation/Reservation.js
+++ b/src/pages/reservation/Reservation.js
@@ -5,22 +5,10 @@ import Sub from './components/Sub';
 import { ReservationStyle } from './Reservation.Styled';
 
 const Reservation = () => {
-  const [inputs, setInputs] = useState({
-    userName: '',
-    phone: '',
-    coupon: 0,
-    pointInput: '',
-  });
-  const [point, setPoint] = useState(0);
   const [checkList, setCheckList] = useState([]);
   const [nameValid, setNameValid] = useState(false);
   const [phoneValid, setPhoneValid] = useState(false);
-  const [modalMsg, setModalMsg] = useState();
-
-  useEffect(() => {
-    localStorage.getItem('token') !== null && setNameValid(true);
-    localStorage.getItem('token') !== null && setPhoneValid(true);
-  }, []);
+  const [modalMsg, setModalMsg] = useState('');
 
   useEffect(() => {
     !nameValid
@@ -32,13 +20,16 @@ const Reservation = () => {
       : setModalMsg('결제하시겠습니까?');
   }, [nameValid, phoneValid, checkList]);
 
+  useEffect(() => {
+    if (localStorage.getItem('token') !== null) {
+      setNameValid(true);
+      setPhoneValid(true);
+    }
+  }, []);
+
   return (
     <ReservationStyle>
       <Main
-        inputs={inputs}
-        setInputs={setInputs}
-        point={point}
-        setPoint={setPoint}
         checkList={checkList}
         setCheckList={setCheckList}
         nameValid={nameValid}

--- a/src/pages/reservation/Reservation.js
+++ b/src/pages/reservation/Reservation.js
@@ -1,11 +1,10 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Main from './components/Main';
 import Sub from './components/Sub';
 
 import { ReservationStyle } from './Reservation.Styled';
 
 const Reservation = () => {
-  // const [submitName, setSubmitName] = useState();
   const [inputs, setInputs] = useState({
     userName: '',
     phone: '',
@@ -14,7 +13,24 @@ const Reservation = () => {
   });
   const [point, setPoint] = useState(0);
   const [checkList, setCheckList] = useState([]);
-  const [nameValid, setNameValid] = useState(true);
+  const [nameValid, setNameValid] = useState(false);
+  const [phoneValid, setPhoneValid] = useState(false);
+  const [modalMsg, setModalMsg] = useState();
+
+  useEffect(() => {
+    localStorage.getItem('token') !== null && setNameValid(true);
+    localStorage.getItem('token') !== null && setPhoneValid(true);
+  }, []);
+
+  useEffect(() => {
+    !nameValid
+      ? setModalMsg('예약자 이름을 확인해주세요.')
+      : !phoneValid
+      ? setModalMsg('휴대폰번호를 확인해주세요.')
+      : checkList.length !== 3
+      ? setModalMsg('필수동의 항목을 확인하세요.')
+      : setModalMsg('결제하시겠습니까?');
+  }, [nameValid, phoneValid, checkList]);
 
   return (
     <ReservationStyle>
@@ -27,8 +43,10 @@ const Reservation = () => {
         setCheckList={setCheckList}
         nameValid={nameValid}
         setNameValid={setNameValid}
+        phoneValid={phoneValid}
+        setPhoneValid={setPhoneValid}
       />
-      <Sub inputs={inputs} point={point} checkList={checkList} />
+      <Sub modalMsg={modalMsg} />
     </ReservationStyle>
   );
 };

--- a/src/pages/reservation/components/Main.js
+++ b/src/pages/reservation/components/Main.js
@@ -1,17 +1,29 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import axios from 'axios';
 import { useRecoilState } from 'recoil';
 import { reservInfoState } from '../../../atom';
 
 import { MainContainerStyle } from './Main.Styled';
 
-const Main = ({ inputs, setInputs, point, setPoint, checkList, setCheckList, nameValid, setNameValid }) => {
+const Main = ({
+  inputs,
+  setInputs,
+  point,
+  setPoint,
+  checkList,
+  setCheckList,
+  nameValid,
+  setNameValid,
+  phoneValid,
+  setPhoneValid,
+}) => {
   const [info] = useRecoilState(reservInfoState);
   const { userName, phone, coupon, pointInput } = inputs;
-  const [phoneValid, setPhoneValid] = useState(true);
 
   useEffect(() => {
     if (localStorage.getItem('token') !== null) {
+      setNameValid(true);
+      setPhoneValid(true);
       axios
         .get('/data/my/userInfo.json')
         // .get('http://localhost:8000/my', { headers: { Authorization: `Bearer ${localStorage.getItem('token')}` } })
@@ -46,7 +58,6 @@ const Main = ({ inputs, setInputs, point, setPoint, checkList, setCheckList, nam
       ...inputs,
       [id]: value,
     });
-    // setSubmitName(inputs.name);
   };
 
   const handledNameInput = (e) => {

--- a/src/pages/reservation/components/Main.js
+++ b/src/pages/reservation/components/Main.js
@@ -1,37 +1,32 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import axios from 'axios';
 import { useRecoilState } from 'recoil';
 import { reservInfoState } from '../../../atom';
 
 import { MainContainerStyle } from './Main.Styled';
 
-const Main = ({
-  inputs,
-  setInputs,
-  point,
-  setPoint,
-  checkList,
-  setCheckList,
-  nameValid,
-  setNameValid,
-  phoneValid,
-  setPhoneValid,
-}) => {
+const Main = ({ checkList, setCheckList, nameValid, setNameValid, phoneValid, setPhoneValid }) => {
   const [info] = useRecoilState(reservInfoState);
+  const [inputs, setInputs] = useState({
+    userName: '',
+    phone: '',
+    coupon: 0,
+    pointInput: '',
+  });
   const { userName, phone, coupon, pointInput } = inputs;
+  const [point, setPoint] = useState(0);
 
   useEffect(() => {
     if (localStorage.getItem('token') !== null) {
-      setNameValid(true);
-      setPhoneValid(true);
       axios
         .get('/data/my/userInfo.json')
         // .get('http://localhost:8000/my', { headers: { Authorization: `Bearer ${localStorage.getItem('token')}` } })
         .then((res) => {
           setInputs({
-            ...inputs,
             userName: res.data.data[0].userName,
             phone: res.data.data[0].userPhoneNumber,
+            coupon: 0,
+            pointInput: '',
           });
         })
         .catch((err) => console.log(err));

--- a/src/pages/reservation/components/Main.js
+++ b/src/pages/reservation/components/Main.js
@@ -5,19 +5,10 @@ import { reservInfoState } from '../../../atom';
 
 import { MainContainerStyle } from './Main.Styled';
 
-const Main = () => {
+const Main = ({ inputs, setInputs, point, setPoint, checkList, setCheckList, nameValid, setNameValid }) => {
   const [info] = useRecoilState(reservInfoState);
-  const [inputs, setInputs] = useState({
-    userName: '',
-    phone: '',
-    coupon: 0,
-    pointInput: '',
-  });
-  const [point, setPoint] = useState(0);
   const { userName, phone, coupon, pointInput } = inputs;
-  const [checkList, setCheckList] = useState([]);
   const [phoneValid, setPhoneValid] = useState(true);
-  const [nameValid, setNameValid] = useState(true);
 
   useEffect(() => {
     if (localStorage.getItem('token') !== null) {
@@ -55,6 +46,7 @@ const Main = () => {
       ...inputs,
       [id]: value,
     });
+    // setSubmitName(inputs.name);
   };
 
   const handledNameInput = (e) => {

--- a/src/pages/reservation/components/Main.js
+++ b/src/pages/reservation/components/Main.js
@@ -51,7 +51,7 @@ const Main = ({ inputs, setInputs, point, setPoint, checkList, setCheckList, nam
 
   const handledNameInput = (e) => {
     const valid = /^[0-9|a-zA-Z|ㄱ-ㅎ|ㅏ-ㅣ|가-힣 ]*$/;
-    6 > e.target.value.length > 0 && e.target.value.split(' ').length - 1 < 2 && valid.test(e.target.value)
+    21 > e.target.value.length > 0 && e.target.value.split(' ').length - 1 < 2 && valid.test(e.target.value)
       ? setNameValid(true)
       : setNameValid(false);
   };
@@ -89,7 +89,7 @@ const Main = ({ inputs, setInputs, point, setPoint, checkList, setCheckList, nam
                 }}
               />
               <div className={` name-valid input-valid small-text ${nameValid && 'none'}`}>
-                한글, 영문, 숫자 5자리 입력 가능.(문자 사이 공백은 1칸만 입력 가능)
+                한글, 영문, 숫자 20자리 입력 가능.(문자 사이 공백은 1칸만 입력 가능)
               </div>
             </div>
             <div>

--- a/src/pages/reservation/components/Sub.js
+++ b/src/pages/reservation/components/Sub.js
@@ -10,12 +10,12 @@ const Sub = ({ modalMsg, setModalMsg }) => {
   const [startDate] = useRecoilState(startDateState);
   const [endDate] = useRecoilState(endDateState);
   const [info] = useRecoilState(reservInfoState);
-  const [reservModal, setReservModal] = useState(false);
+  const [modal, setModal] = useState(false);
   const period = Math.ceil((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24));
   const week = ['일', '월', '화', '수', '목', '금', '토'];
 
-  const clickReservBtn = () => {
-    setReservModal(true);
+  const clickPayBtn = () => {
+    setModal(true);
   };
 
   return (
@@ -71,8 +71,8 @@ const Sub = ({ modalMsg, setModalMsg }) => {
           </div>
         </div>
 
-        <button onClick={clickReservBtn}>결제하기</button>
-        {reservModal && <SubmitModal setReservModal={setReservModal} modalMsg={modalMsg} setModalMsg={setModalMsg} />}
+        <button onClick={clickPayBtn}>결제하기</button>
+        {modal && <SubmitModal setModal={setModal} modalMsg={modalMsg} setModalMsg={setModalMsg} />}
       </SubContainerStyle>
     </>
   );

--- a/src/pages/reservation/components/Sub.js
+++ b/src/pages/reservation/components/Sub.js
@@ -1,14 +1,84 @@
+import { useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { startDateState, endDateState, reservInfoState } from '../../../atom';
+import styled from 'styled-components';
 
 import { SubContainerStyle } from '../Reservation.Styled';
+
+const ModalContainer = styled.div`
+  .bg {
+    display: 'flex';
+    position: fixed;
+    top: 0%;
+    left: 0%;
+    height: 100vh;
+    width: 100vw;
+    background-color: #000000c7;
+    color: ${({ theme }) => theme.colors.text};
+    z-index: 99;
+  }
+
+  .reserv-container {
+    position: fixed;
+    top: 38%;
+    left: 40%;
+    width: 360px;
+    margin: auto;
+    background-color: #fff;
+    border-radius: 8px;
+    z-index: 100;
+
+    p {
+      width: 100%;
+      padding: 50px 30px 40px;
+      border-bottom: 1px solid #b8b8b8;
+      font-size: 16px;
+      color: #000000de;
+    }
+
+    .reserv-btn {
+      display: flex;
+      justify-content: end;
+      padding: 0px 15px;
+      button {
+        width: 70px;
+        height: 48px;
+        border: none;
+        outline: none;
+        background-color: #fff;
+        font-weight: 700;
+        font-size: 15px;
+        cursor: pointer;
+      }
+      .cancel {
+        color: ${({ theme }) => theme.colors.text};
+      }
+      .submit {
+        color: ${({ theme }) => theme.colors.mainColor};
+      }
+    }
+  }
+`;
 
 const Sub = () => {
   const [startDate] = useRecoilState(startDateState);
   const [endDate] = useRecoilState(endDateState);
   const [info] = useRecoilState(reservInfoState);
+  const [reservModal, setReservModal] = useState(false);
   const period = Math.ceil((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24));
   const week = ['일', '월', '화', '수', '목', '금', '토'];
+
+  const clickReservBtn = () => {
+    setReservModal(true);
+  };
+
+  const clickBg = () => {
+    setReservModal(false);
+  };
+
+  const handleSubmitBtn = () => {
+    setReservModal(false);
+  };
 
   return (
     <>
@@ -55,15 +125,35 @@ const Sub = () => {
               </div>
             </div>
             <ul>
-              <li>해당 객실가는 세금, 봉사료가 포함된 금액입니다</li>
+              <li>해당 객실가는 세금, 봉사료가 포함된 금액입니다.</li>
               <li>
-                결제완료 후 <span>예약자 이름</span>으로 바로 <span>체크인</span> 하시면 됩니다
+                결제완료 후 <span>예약자 이름</span>으로 바로 <span>체크인</span> 하시면 됩니다.
               </li>
             </ul>
           </div>
         </div>
 
-        <button>결제하기</button>
+        <button onClick={clickReservBtn}>결제하기</button>
+        {reservModal && (
+          <ModalContainer>
+            <div className='bg' onClick={clickBg}></div>
+            <div className='reserv-container'>
+              <p>결제하시겠습니까?</p>
+              <div className='reserv-btn'>
+                <button
+                  className='cancel'
+                  onClick={() => {
+                    setReservModal(false);
+                  }}>
+                  취소
+                </button>
+                <button className='submit' onClick={handleSubmitBtn}>
+                  결제하기
+                </button>
+              </div>
+            </div>
+          </ModalContainer>
+        )}
       </SubContainerStyle>
     </>
   );

--- a/src/pages/reservation/components/Sub.js
+++ b/src/pages/reservation/components/Sub.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { startDateState, endDateState, reservInfoState } from '../../../atom';
 
@@ -6,18 +6,13 @@ import SubmitModal from './SubmitModal';
 
 import { SubContainerStyle } from '../Reservation.Styled';
 
-const Sub = ({ inputs, point, checkList }) => {
+const Sub = ({ modalMsg, setModalMsg }) => {
   const [startDate] = useRecoilState(startDateState);
   const [endDate] = useRecoilState(endDateState);
   const [info] = useRecoilState(reservInfoState);
   const [reservModal, setReservModal] = useState(false);
-  const [modalType, setModalType] = useState('');
   const period = Math.ceil((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24));
   const week = ['일', '월', '화', '수', '목', '금', '토'];
-
-  // useEffect(() => {
-  //   inputs();
-  // }, []);
 
   const clickReservBtn = () => {
     setReservModal(true);
@@ -77,7 +72,7 @@ const Sub = ({ inputs, point, checkList }) => {
         </div>
 
         <button onClick={clickReservBtn}>결제하기</button>
-        {reservModal && <SubmitModal setReservModal={setReservModal} />}
+        {reservModal && <SubmitModal setReservModal={setReservModal} modalMsg={modalMsg} setModalMsg={setModalMsg} />}
       </SubContainerStyle>
     </>
   );

--- a/src/pages/reservation/components/Sub.js
+++ b/src/pages/reservation/components/Sub.js
@@ -1,83 +1,26 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { startDateState, endDateState, reservInfoState } from '../../../atom';
-import styled from 'styled-components';
+
+import SubmitModal from './SubmitModal';
 
 import { SubContainerStyle } from '../Reservation.Styled';
 
-const ModalContainer = styled.div`
-  .bg {
-    display: 'flex';
-    position: fixed;
-    top: 0%;
-    left: 0%;
-    height: 100vh;
-    width: 100vw;
-    background-color: #000000c7;
-    color: ${({ theme }) => theme.colors.text};
-    z-index: 99;
-  }
-
-  .reserv-container {
-    position: fixed;
-    top: 38%;
-    left: 40%;
-    width: 360px;
-    margin: auto;
-    background-color: #fff;
-    border-radius: 8px;
-    z-index: 100;
-
-    p {
-      width: 100%;
-      padding: 50px 30px 40px;
-      border-bottom: 1px solid #b8b8b8;
-      font-size: 16px;
-      color: #000000de;
-    }
-
-    .reserv-btn {
-      display: flex;
-      justify-content: end;
-      padding: 0px 15px;
-      button {
-        width: 70px;
-        height: 48px;
-        border: none;
-        outline: none;
-        background-color: #fff;
-        font-weight: 700;
-        font-size: 15px;
-        cursor: pointer;
-      }
-      .cancel {
-        color: ${({ theme }) => theme.colors.text};
-      }
-      .submit {
-        color: ${({ theme }) => theme.colors.mainColor};
-      }
-    }
-  }
-`;
-
-const Sub = () => {
+const Sub = ({ inputs, point, checkList }) => {
   const [startDate] = useRecoilState(startDateState);
   const [endDate] = useRecoilState(endDateState);
   const [info] = useRecoilState(reservInfoState);
   const [reservModal, setReservModal] = useState(false);
+  const [modalType, setModalType] = useState('');
   const period = Math.ceil((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24));
   const week = ['일', '월', '화', '수', '목', '금', '토'];
 
+  // useEffect(() => {
+  //   inputs();
+  // }, []);
+
   const clickReservBtn = () => {
     setReservModal(true);
-  };
-
-  const clickBg = () => {
-    setReservModal(false);
-  };
-
-  const handleSubmitBtn = () => {
-    setReservModal(false);
   };
 
   return (
@@ -134,26 +77,7 @@ const Sub = () => {
         </div>
 
         <button onClick={clickReservBtn}>결제하기</button>
-        {reservModal && (
-          <ModalContainer>
-            <div className='bg' onClick={clickBg}></div>
-            <div className='reserv-container'>
-              <p>결제하시겠습니까?</p>
-              <div className='reserv-btn'>
-                <button
-                  className='cancel'
-                  onClick={() => {
-                    setReservModal(false);
-                  }}>
-                  취소
-                </button>
-                <button className='submit' onClick={handleSubmitBtn}>
-                  결제하기
-                </button>
-              </div>
-            </div>
-          </ModalContainer>
-        )}
+        {reservModal && <SubmitModal setReservModal={setReservModal} />}
       </SubContainerStyle>
     </>
   );

--- a/src/pages/reservation/components/SubmitModal.js
+++ b/src/pages/reservation/components/SubmitModal.js
@@ -65,7 +65,7 @@ const ModalContainer = styled.div`
   }
 `;
 
-const SubmitModal = ({ setReservModal, modalMsg }) => {
+const SubmitModal = ({ setModal, modalMsg }) => {
   const [submit, setSubmit] = useState(false);
   const [completeMsg, setCompleteMsg] = useState(false);
 
@@ -78,7 +78,8 @@ const SubmitModal = ({ setReservModal, modalMsg }) => {
   }, [modalMsg]);
 
   const handleModal = () => {
-    setReservModal(false);
+    setModal(false);
+    completeMsg && window.location.replace('/');
   };
 
   const handlePayBtn = () => {
@@ -100,34 +101,23 @@ const SubmitModal = ({ setReservModal, modalMsg }) => {
           </p>
         )}
         <div className='reserv-btn'>
-          <button
-            className={`cancel ${submit && 'block'}`}
-            onClick={() => {
-              setReservModal(false);
-            }}>
+          <button className={`cancel ${submit && 'block'}`} onClick={handleModal}>
             취소
           </button>
           {!submit && !completeMsg && (
-            <button
-              className='submit'
-              onClick={() => {
-                handleModal();
-              }}>
+            <button className='submit' onClick={handleModal}>
               확인
             </button>
-            // 결제 불가능할때
           )}
           {submit && (
             <button className='submit' onClick={handlePayBtn}>
               결제하기
             </button>
           )}
-          {/* 결제가능할 때 */}
           {completeMsg && (
             <button className='submit' onClick={handleModal}>
               확인
             </button>
-            // 결제 후 확인버튼
           )}
         </div>
       </div>

--- a/src/pages/reservation/components/SubmitModal.js
+++ b/src/pages/reservation/components/SubmitModal.js
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 const ModalContainer = styled.div`
@@ -31,6 +32,11 @@ const ModalContainer = styled.div`
       color: #000000de;
     }
 
+    .complete-msg {
+      line-height: 25px;
+      padding: 35px 30px 25px;
+    }
+
     .reserv-btn {
       display: flex;
       justify-content: end;
@@ -47,39 +53,82 @@ const ModalContainer = styled.div`
       }
       .cancel {
         color: ${({ theme }) => theme.colors.text};
+        display: none;
       }
       .submit {
         color: ${({ theme }) => theme.colors.mainColor};
+      }
+      .block {
+        display: block;
       }
     }
   }
 `;
 
-const SubmitModal = ({ setReservModal }) => {
-  const clickBg = () => {
+const SubmitModal = ({ setReservModal, modalMsg }) => {
+  const [submit, setSubmit] = useState(false);
+  const [completeMsg, setCompleteMsg] = useState(false);
+
+  useEffect(() => {
+    if (modalMsg === '결제하시겠습니까?') {
+      setSubmit(true);
+    } else {
+      setSubmit(false);
+    }
+  }, [modalMsg]);
+
+  const handleModal = () => {
     setReservModal(false);
   };
 
-  const handleSubmitBtn = () => {
-    setReservModal(false);
+  const handlePayBtn = () => {
+    setSubmit(false);
+    setCompleteMsg(true);
   };
 
   return (
     <ModalContainer>
-      <div className='bg' onClick={clickBg}></div>
+      <div className='bg' onClick={handleModal}></div>
       <div className='reserv-container'>
-        <p>결제하시겠습니까?</p>
+        {!completeMsg ? (
+          <p>{modalMsg}</p>
+        ) : (
+          <p className='complete-msg'>
+            결제가 완료되었습니다.
+            <br />
+            마이페이지에서 예약내역을 확인하세요.
+          </p>
+        )}
         <div className='reserv-btn'>
           <button
-            className='cancel'
+            className={`cancel ${submit && 'block'}`}
             onClick={() => {
               setReservModal(false);
             }}>
             취소
           </button>
-          <button className='submit' onClick={handleSubmitBtn}>
-            결제하기
-          </button>
+          {!submit && !completeMsg && (
+            <button
+              className='submit'
+              onClick={() => {
+                handleModal();
+              }}>
+              확인
+            </button>
+            // 결제 불가능할때
+          )}
+          {submit && (
+            <button className='submit' onClick={handlePayBtn}>
+              결제하기
+            </button>
+          )}
+          {/* 결제가능할 때 */}
+          {completeMsg && (
+            <button className='submit' onClick={handleModal}>
+              확인
+            </button>
+            // 결제 후 확인버튼
+          )}
         </div>
       </div>
     </ModalContainer>

--- a/src/pages/reservation/components/SubmitModal.js
+++ b/src/pages/reservation/components/SubmitModal.js
@@ -1,0 +1,89 @@
+import styled from 'styled-components';
+
+const ModalContainer = styled.div`
+  .bg {
+    display: 'flex';
+    position: fixed;
+    top: 0%;
+    left: 0%;
+    height: 100vh;
+    width: 100vw;
+    background-color: #000000c7;
+    color: ${({ theme }) => theme.colors.text};
+    z-index: 99;
+  }
+
+  .reserv-container {
+    position: fixed;
+    top: 38%;
+    left: 40%;
+    width: 360px;
+    margin: auto;
+    background-color: #fff;
+    border-radius: 8px;
+    z-index: 100;
+
+    p {
+      width: 100%;
+      padding: 50px 30px 40px;
+      border-bottom: 1px solid #b8b8b8;
+      font-size: 16px;
+      color: #000000de;
+    }
+
+    .reserv-btn {
+      display: flex;
+      justify-content: end;
+      padding: 0px 15px;
+      button {
+        width: 70px;
+        height: 48px;
+        border: none;
+        outline: none;
+        background-color: #fff;
+        font-weight: 700;
+        font-size: 15px;
+        cursor: pointer;
+      }
+      .cancel {
+        color: ${({ theme }) => theme.colors.text};
+      }
+      .submit {
+        color: ${({ theme }) => theme.colors.mainColor};
+      }
+    }
+  }
+`;
+
+const SubmitModal = ({ setReservModal }) => {
+  const clickBg = () => {
+    setReservModal(false);
+  };
+
+  const handleSubmitBtn = () => {
+    setReservModal(false);
+  };
+
+  return (
+    <ModalContainer>
+      <div className='bg' onClick={clickBg}></div>
+      <div className='reserv-container'>
+        <p>결제하시겠습니까?</p>
+        <div className='reserv-btn'>
+          <button
+            className='cancel'
+            onClick={() => {
+              setReservModal(false);
+            }}>
+            취소
+          </button>
+          <button className='submit' onClick={handleSubmitBtn}>
+            결제하기
+          </button>
+        </div>
+      </div>
+    </ModalContainer>
+  );
+};
+
+export default SubmitModal;

--- a/src/pages/reservation/components/SubmitModal.js
+++ b/src/pages/reservation/components/SubmitModal.js
@@ -100,7 +100,7 @@ const SubmitModal = ({ setModal, modalMsg }) => {
           <button className={`cancel ${submit && 'block'}`} onClick={handleModal}>
             취소
           </button>
-          {!submit && !completeMsg && (
+          {!submit && (
             <button className='submit' onClick={handleModal}>
               확인
             </button>
@@ -108,11 +108,6 @@ const SubmitModal = ({ setModal, modalMsg }) => {
           {submit && (
             <button className='submit' onClick={handlePayBtn}>
               결제하기
-            </button>
-          )}
-          {completeMsg && (
-            <button className='submit' onClick={handleModal}>
-              확인
             </button>
           )}
         </div>

--- a/src/pages/reservation/components/SubmitModal.js
+++ b/src/pages/reservation/components/SubmitModal.js
@@ -8,7 +8,7 @@ const ModalContainer = styled.div`
     left: 0%;
     height: 100vh;
     width: 100vw;
-    background-color: #000000c7;
+    background-color: ${({ theme }) => theme.colors.modalBg};
     color: ${({ theme }) => theme.colors.text};
     z-index: 99;
   }

--- a/src/pages/reservation/components/SubmitModal.js
+++ b/src/pages/reservation/components/SubmitModal.js
@@ -70,11 +70,7 @@ const SubmitModal = ({ setModal, modalMsg }) => {
   const [completeMsg, setCompleteMsg] = useState(false);
 
   useEffect(() => {
-    if (modalMsg === '결제하시겠습니까?') {
-      setSubmit(true);
-    } else {
-      setSubmit(false);
-    }
+    modalMsg === '결제하시겠습니까?' ? setSubmit(true) : setSubmit(false);
   }, [modalMsg]);
 
   const handleModal = () => {


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 예약페이지에서 유효성검사 기준에 따라 생성되는 모달의 내용 변경

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 메인컨테이너에서만 관리하던 예약자이름, 폰번호, 약관 valid 상태를
예약페이지 전체에서 관리 -> valid 상태에 따라 결제하기 버튼을 클릭 했을 시 메세지가 다르도록 설정

2. 예약완료 후 메인페이지로 이동

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 어떤 상태를 큰 페이지에서 공통으로 관리해야 같이 쓸 수 있는지 고민하게 됨. 
처음에는 모든 상태를 크게 관리하려했는데 공통으로 사용하는 상태만 크게 관리해야
코드가 지저분해지지 않는 것같아서 수정함


